### PR TITLE
Revamp layout with dedicated pages

### DIFF
--- a/actions.html
+++ b/actions.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>M'Hunters Ladder - Actions</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <header class="hero">
+        <img src="images/banner.png" alt="M'Hunters Clan Ladder" class="banner-image">
+    </header>
+
+    <nav class="site-nav">
+        <div class="site-nav__inner">
+            <a class="nav-logo" href="index.html">M'Hunters Ladder</a>
+            <div class="site-nav__links">
+                <a href="index.html">Home</a>
+                <a href="history.html">History</a>
+                <a class="active" href="actions.html">Actions</a>
+                <a href="help.html">Help</a>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <section class="panel">
+            <div class="panel__header">
+                <div>
+                    <p class="eyebrow">Manage</p>
+                    <h2>Player actions</h2>
+                </div>
+                <span class="chip chip--info">Self-serve</span>
+            </div>
+            <div class="actions">
+                <div class="card">
+                    <h3>Join Ladder</h3>
+                    <label for="join-name">Warzone username</label>
+                    <input type="text" id="join-name" placeholder="Enter your username">
+                    <label for="join-id">Player ID</label>
+                    <input type="number" id="join-id" placeholder="Your Player ID" min="1" step="1">
+                    <button onclick="joinLadder()">Join / Activate</button>
+                    <small>Opens a GitHub issue to register.</small>
+                </div>
+
+                <div class="card">
+                    <h3>Update Game Cap</h3>
+                    <label for="update-id">Player ID</label>
+                    <input type="number" id="update-id" placeholder="Your Player ID" min="1" step="1">
+                    <label for="update-cap">Game cap</label>
+                    <select id="update-cap">
+                        <option value="0">Paused (0 Games)</option>
+                        <option value="1">1 Game</option>
+                        <option value="2" selected>2 Games (Default)</option>
+                        <option value="3">3 Games (Max)</option>
+                    </select>
+                    <button onclick="updateSettings()">Update Cap</button>
+                    <small>Opens a GitHub issue to change settings.</small>
+                </div>
+            </div>
+        </section>
+
+        <section class="panel">
+            <div class="panel__header">
+                <div>
+                    <p class="eyebrow">Cleanup</p>
+                    <h2>Remove Player</h2>
+                </div>
+                <span class="chip chip--danger">Admin</span>
+            </div>
+            <div class="input-group">
+                <label for="remove-id">Player ID</label>
+                <div class="input-stack">
+                    <input type="number" id="remove-id" placeholder="Player ID" min="1" step="1">
+                    <button class="btn btn-danger" onclick="removePlayer()">Remove</button>
+                </div>
+                <p class="help-text">Opens a GitHub issue to request removal.</p>
+            </div>
+        </section>
+    </main>
+
+    <script src="app.js"></script>
+</body>
+
+</html>

--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ function validatePlayerId(id) {
 
 function renderLeaderboard(players) {
     const tbody = document.getElementById('leaderboard-body');
+    if (!tbody) return;
     tbody.innerHTML = '';
 
     const allPlayers = Object.entries(players).map(([id, p]) => ({ ...p, id }));
@@ -157,6 +158,7 @@ function toggleDetails(id) {
 
 function renderGames(games, players) {
     const container = document.getElementById('games-list');
+    if (!container) return;
     container.innerHTML = '';
 
     if (games.length === 0) {
@@ -197,40 +199,21 @@ function renderGames(games, players) {
     container.appendChild(table);
 }
 
-// Load Templates (if present in global scope or pass it down)
-// NOTE: loadData() fetches history but not templates. We need to fetch templates too.
-// Ideally loadData should have fetched templates. Let's patch loadData first?
-// Or just fetch here if not cached. 
-// To minimize changes, I will rely on a globally available templates object or fetch it.
-// Let's assume passed as argument or I'll patch loadData to pass it. 
-// Wait, refactored loadData first.
-
-// ... Actually, let's just make loadData fetch templates.
-// But I am confined to this replacement chunk.
-// I will use a simple map ID check. Or I should update loadData first.
-// The prompt allows me to edit app.js. I'll edit loadData AND renderHistory.
-// BUT replace_file_content is single block (unless I use multi).
-// Let's use MultiReplace!!
-
-// Cancelling this tool call to use MultiReplace.
-// Wait, I can't cancel. I will just update THIS chunk to EXPECT templates,
-// and then I will use another call to update loadData.
-// Or I can do it all in one multi-replace.
-// I will output a dummy change here? No, better to ERROR and use multi?
-// No, I'll just change renderHistory signature and logic, then update loadData in next step.
-
-
-function renderHistory(history, players) {
-    const container = document.getElementById('history-list');
+function renderHistory(history, players, { limit = null, containerId = 'history-list' } = {}) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
     container.innerHTML = '';
 
-    const validGames = history
+    let validGames = history
         .filter(h => h.winner_id || (h.note === 'Draw') || (h.note && !h.note.includes('Timed Out') && !h.note.includes('Terminated')))
-        .reverse()
-        .slice(0, 20);
+        .reverse();
+
+    if (limit) {
+        validGames = validGames.slice(0, limit);
+    }
 
     if (validGames.length === 0) {
-        container.innerHTML = '<p>No recent history.</p>';
+        container.innerHTML = '<p>No history available yet.</p>';
         return;
     }
 

--- a/help.html
+++ b/help.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>M'Hunters Ladder - Help</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <header class="hero">
+        <img src="images/banner.png" alt="M'Hunters Clan Ladder" class="banner-image">
+    </header>
+
+    <nav class="site-nav">
+        <div class="site-nav__inner">
+            <a class="nav-logo" href="index.html">M'Hunters Ladder</a>
+            <div class="site-nav__links">
+                <a href="index.html">Home</a>
+                <a href="history.html">History</a>
+                <a href="actions.html">Actions</a>
+                <a class="active" href="help.html">Help</a>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <section class="panel">
+            <div class="panel__header">
+                <div>
+                    <p class="eyebrow">Guidance</p>
+                    <h2>How to use the ladder</h2>
+                </div>
+                <span class="chip chip--info">Quick tips</span>
+            </div>
+            <div class="help-copy">
+                <h3>Sign up</h3>
+                <p>Open a new GitHub issue with the title:</p>
+                <pre><code>Signup: &lt;Your_Warzone_ID&gt; Name: &lt;Your_Warzone_Username&gt;</code></pre>
+                <p>Example: <code>Signup: 1234567 Name: General_Risk</code></p>
+
+                <h3>Update your game cap</h3>
+                <p>Limits your simultaneous ladder games (default 2, max 3, set to 0 to pause).</p>
+                <pre><code>Update: &lt;Your_Warzone_ID&gt; Cap: &lt;GameLimit&gt;</code></pre>
+                <p>Example: <code>Update: 1234567 Cap: 3</code></p>
+
+                <h3>Remove yourself</h3>
+                <pre><code>Remove: &lt;Your_Warzone_ID&gt;</code></pre>
+                <p>Example: <code>Remove: 1234567</code></p>
+
+                <h3>What to expect</h3>
+                <ul>
+                    <li>The bot checks the ladder every few hours to create or clean up games.</li>
+                    <li>Missing two games in a row will mark you inactive until you join another match.</li>
+                    <li>You can always re-activate by joining a game or updating your status.</li>
+                </ul>
+
+                <p class="inline-note">Need to take action right now? Visit the <a href="actions.html">Actions page</a>.</p>
+            </div>
+        </section>
+    </main>
+
+    <script src="app.js"></script>
+</body>
+
+</html>

--- a/history.html
+++ b/history.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>M'Hunters Ladder - History</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+
+    <header class="hero">
+        <img src="images/banner.png" alt="M'Hunters Clan Ladder" class="banner-image">
+    </header>
+
+    <nav class="site-nav">
+        <div class="site-nav__inner">
+            <a class="nav-logo" href="index.html">M'Hunters Ladder</a>
+            <div class="site-nav__links">
+                <a href="index.html">Home</a>
+                <a class="active" href="history.html">History</a>
+                <a href="actions.html">Actions</a>
+                <a href="help.html">Help</a>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <section class="panel">
+            <div class="panel__header">
+                <div>
+                    <p class="eyebrow">Archive</p>
+                    <h2>All reported games</h2>
+                </div>
+                <span class="chip">Growing log</span>
+            </div>
+            <div id="history-list">
+                <p>Loading...</p>
+            </div>
+        </section>
+    </main>
+
+    <script src="app.js"></script>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -11,18 +11,20 @@
 <body>
 
     <header class="hero">
-        <div class="hero__overlay"></div>
         <img src="images/banner.png" alt="M'Hunters Clan Ladder" class="banner-image">
-        <div class="hero__content">
-            <p class="eyebrow">M'Hunters Clan</p>
-            <h1>Battle-ready ladder for the community</h1>
-            <p class="lede">Track the top performers, jump into live games, and keep your slot active with a couple clicks.</p>
-            <div class="hero__actions">
-                <a href="#control-panel" class="btn primary">Join or update</a>
-                <a href="#history-section" class="btn ghost">Recent history</a>
+    </header>
+
+    <nav class="site-nav">
+        <div class="site-nav__inner">
+            <a class="nav-logo" href="index.html">M'Hunters Ladder</a>
+            <div class="site-nav__links">
+                <a class="active" href="index.html">Home</a>
+                <a href="history.html">History</a>
+                <a href="actions.html">Actions</a>
+                <a href="help.html">Help</a>
             </div>
         </div>
-    </header>
+    </nav>
 
     <main>
 
@@ -49,44 +51,6 @@
                 </table>
             </section>
 
-            <section id="control-panel" class="panel">
-                <div class="panel__header">
-                    <div>
-                        <p class="eyebrow">Manage</p>
-                        <h2>Actions</h2>
-                    </div>
-                    <span class="chip chip--info">Self-serve</span>
-                </div>
-                <div class="actions">
-                    <div class="card">
-                        <h3>Join Ladder</h3>
-                        <label for="join-name">Warzone username</label>
-                        <input type="text" id="join-name" placeholder="Enter your username">
-                        <label for="join-id">Player ID</label>
-                        <input type="number" id="join-id" placeholder="Your Player ID" min="1" step="1">
-                        <button onclick="joinLadder()">Join / Activate</button>
-                        <small>Opens a GitHub issue to register.</small>
-                    </div>
-
-                    <div class="card">
-                        <h3>Update Settings</h3>
-                        <label for="update-id">Player ID</label>
-                        <input type="number" id="update-id" placeholder="Your Player ID" min="1" step="1">
-                        <label for="update-cap">Game cap</label>
-                        <select id="update-cap">
-                            <option value="0">Paused (0 Games)</option>
-                            <option value="1">1 Game</option>
-                            <option value="2" selected>2 Games (Default)</option>
-                            <option value="3">3 Games (Max)</option>
-                        </select>
-                        <button onclick="updateSettings()">Update Cap</button>
-                        <small>Opens a GitHub issue to change settings.</small>
-                    </div>
-                </div>
-            </section>
-        </section>
-
-        <section class="panel-grid two-up">
             <section id="games-section" class="panel">
                 <div class="panel__header">
                     <div>
@@ -100,43 +64,28 @@
                     <p>Loading...</p>
                 </div>
             </section>
-
-            <section id="history-section" class="panel">
-                <div class="panel__header">
-                    <div>
-                        <p class="eyebrow">Archive</p>
-                        <h2>Recent History</h2>
-                    </div>
-                    <span class="chip">Collapsible</span>
-                </div>
-                <details open>
-                    <summary>
-                        <span>Last 20 reported games</span>
-                        <span class="summary-pill">Tap to toggle</span>
-                    </summary>
-                    <div id="history-list">
-                        <!-- JS will populate -->
-                        <p>Loading...</p>
-                    </div>
-                </details>
-            </section>
         </section>
 
-        <section class="panel">
+        <section class="panel quick-links">
             <div class="panel__header">
                 <div>
-                    <p class="eyebrow">Cleanup</p>
-                    <h2>Remove Player</h2>
+                    <p class="eyebrow">More</p>
+                    <h2>Explore the ladder</h2>
                 </div>
-                <span class="chip chip--danger">Admin</span>
             </div>
-            <div class="input-group">
-                <label for="remove-id">Player ID</label>
-                <div class="input-stack">
-                    <input type="number" id="remove-id" placeholder="Player ID" min="1" step="1">
-                    <button class="btn btn-danger" onclick="removePlayer()">Remove</button>
-                </div>
-                <p class="help-text">Opens a GitHub issue to request removal.</p>
+            <div class="link-grid">
+                <a class="card link-card" href="actions.html">
+                    <h3>Player actions</h3>
+                    <p>Sign up, change your game cap, or remove a player through the Actions page.</p>
+                </a>
+                <a class="card link-card" href="history.html">
+                    <h3>Full history</h3>
+                    <p>Browse every reported match in the ladder archive.</p>
+                </a>
+                <a class="card link-card" href="help.html">
+                    <h3>Help</h3>
+                    <p>Get quick instructions for joining, updating your cap, or stepping away.</p>
+                </a>
             </div>
         </section>
     </main>

--- a/style.css
+++ b/style.css
@@ -31,9 +31,64 @@ body {
     min-height: 100vh;
 }
 
+.site-nav {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    backdrop-filter: blur(8px);
+    background: rgba(12, 18, 36, 0.9);
+    border-bottom: 1px solid var(--border);
+}
+
+.site-nav__inner {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0.85rem var(--gutter);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.nav-logo {
+    font-weight: 800;
+    color: #f7f9ff;
+    text-decoration: none;
+    letter-spacing: 0.01em;
+}
+
+.site-nav__links {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.site-nav__links a {
+    color: var(--muted);
+    text-decoration: none;
+    font-weight: 700;
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    transition: color 0.12s ease, background 0.12s ease, border 0.12s ease;
+    border: 1px solid transparent;
+}
+
+.site-nav__links a:hover {
+    color: var(--text);
+    background: rgba(255, 255, 255, 0.04);
+    border-color: var(--border);
+}
+
+.site-nav__links .active {
+    color: #0b1525;
+    background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+    border: none;
+}
+
 main {
     max-width: var(--max-width);
-    margin: -60px auto 3rem;
+    margin: 1.5rem auto 3rem;
     padding: 0 var(--gutter);
     position: relative;
     z-index: 1;
@@ -55,50 +110,17 @@ p {
 header.hero {
     position: relative;
     overflow: hidden;
-    height: 280px;
-    display: flex;
-    align-items: flex-end;
-    justify-content: flex-start;
-    border-bottom: 1px solid var(--border);
     background: #060a17;
-}
-
-.hero__overlay {
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(180deg, rgba(6, 10, 23, 0) 35%, rgba(6, 10, 23, 0.75) 100%);
-    z-index: 1;
+    border-bottom: 1px solid var(--border);
 }
 
 .banner-image {
-    position: absolute;
-    inset: 0;
+    display: block;
     width: 100%;
-    height: 100%;
-    object-fit: cover;
-    opacity: 0.9;
+    height: auto;
+    object-fit: contain;
+    max-height: 420px;
     filter: saturate(1.05);
-}
-
-.hero__content {
-    position: relative;
-    z-index: 2;
-    padding: 2.5rem;
-    max-width: var(--max-width);
-    width: 100%;
-    margin: 0 auto;
-    text-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
-}
-
-.hero__content h1 {
-    font-size: clamp(2rem, 3vw + 1rem, 3rem);
-    letter-spacing: -0.02em;
-    margin: 0.35rem 0 0.5rem;
-}
-
-.lede {
-    max-width: 700px;
-    line-height: 1.5;
 }
 
 .eyebrow {
@@ -108,13 +130,6 @@ header.hero {
     font-size: 0.8rem;
     color: var(--accent);
     margin: 0;
-}
-
-.hero__actions {
-    display: flex;
-    gap: 0.8rem;
-    margin-top: 1.2rem;
-    flex-wrap: wrap;
 }
 
 .btn {
@@ -181,9 +196,57 @@ header.hero {
     grid-template-columns: 1fr 1fr;
 }
 
+.quick-links {
+    margin-top: 0.5rem;
+}
+
+.link-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.link-card {
+    color: var(--text);
+    text-decoration: none;
+    transition: border-color 0.15s ease, transform 0.15s ease, background 0.15s ease;
+}
+
+.link-card:hover {
+    border-color: rgba(109, 211, 166, 0.5);
+    transform: translateY(-2px);
+    background: rgba(109, 211, 166, 0.06);
+}
+
+.help-copy h3 {
+    margin-top: 1.25rem;
+}
+
+.help-copy pre {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem;
+    overflow: auto;
+}
+
+.help-copy code {
+    color: #b6d6ff;
+}
+
+.help-copy ul {
+    margin: 0.5rem 0 0.75rem;
+    padding-left: 1.25rem;
+    color: var(--muted);
+}
+
+.help-copy ul li {
+    margin: 0.4rem 0;
+}
+
 @media (max-width: 900px) {
     main {
-        margin-top: -80px;
+        margin-top: 1rem;
     }
     .panel-grid,
     .panel-grid.two-up {
@@ -226,9 +289,14 @@ button {
     margin-top: 0.35rem;
     border-radius: 10px;
     border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.03);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
     color: var(--text);
     font-size: 1rem;
+}
+
+select {
+    cursor: pointer;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 input:focus,


### PR DESCRIPTION
## Summary
- convert the ladder site into dedicated Home, History, Actions, and Help pages with shared navigation
- simplify the hero banner to an image-only header and brighten form controls while keeping the main page focused on leaderboard and live games
- show the entire match history (no 20-game limit) and add clear help content for signing up and managing participation

## Testing
- Not run (static site changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e3b74ec78832d8ecca4afb9f8d1c3)